### PR TITLE
Add eslint rule to prevent importing next/server outside of _middleware

### DIFF
--- a/errors/no-server-import-in-page.md
+++ b/errors/no-server-import-in-page.md
@@ -1,0 +1,23 @@
+# No Server Import In Page
+
+### Why This Error Occurred
+
+`next/server` was imported in a page outside of `pages/_middleware.js` (or `pages/_middleware.tsx` if you are using TypeScript)
+
+### Possible Ways to Fix It
+
+Only import and use `next/server` within `pages/_middleware.js` (or `pages/_middleware.tsx`) to add middlewares.
+
+```jsx
+// pages/_middleware.ts
+
+import type { NextFetchEvent, NextRequest } from 'next/server'
+
+export function middleware(req: NextRequest, ev: NextFetchEvent) {
+  return new Response('Hello, world!')
+}
+```
+
+### Useful Links
+
+- [Middleware](https://nextjs.org/docs/middleware)

--- a/packages/eslint-plugin-next/lib/rules/no-server-import-in-page.js
+++ b/packages/eslint-plugin-next/lib/rules/no-server-import-in-page.js
@@ -1,0 +1,37 @@
+const path = require('path')
+
+module.exports = {
+  meta: {
+    docs: {
+      description:
+        'Disallow importing next/server outside of pages/_middleware.js',
+      recommended: true,
+      url: 'https://nextjs.org/docs/messages/no-server-import-in-page',
+    },
+  },
+  create: function (context) {
+    return {
+      ImportDeclaration(node) {
+        if (node.source.value !== 'next/server') {
+          return
+        }
+
+        const paths = context.getFilename().split('pages')
+        const page = paths[paths.length - 1]
+
+        if (
+          !page ||
+          page.startsWith(`${path.sep}_middleware`) ||
+          page.startsWith(`${path.posix.sep}_middleware`)
+        ) {
+          return
+        }
+
+        context.report({
+          node,
+          message: `next/server should not be imported outside of pages/_middleware.js. See https://nextjs.org/docs/messages/no-server-import-in-page.`,
+        })
+      },
+    }
+  },
+}

--- a/test/unit/eslint-plugin-next/no-server-import-in-page.test.ts
+++ b/test/unit/eslint-plugin-next/no-server-import-in-page.test.ts
@@ -1,0 +1,128 @@
+import { RuleTester } from 'eslint'
+;
+import path from 'path'
+import rule from '@next/eslint-plugin-next/lib/rules/no-server-import-in-page'
+
+(RuleTester as any).setDefaultConfig({
+  parserOptions: {
+    ecmaVersion: 2018,
+    sourceType: 'module',
+    ecmaFeatures: {
+      modules: true,
+      jsx: true,
+    },
+  },
+})
+const ruleTester = new RuleTester()
+
+ruleTester.run('no-server-import-in-page', rule, {
+  valid: [
+    {
+      code: `import { NextFetchEvent, NextRequest } from "next/server"
+
+      export function middleware(req, ev) {
+        return new Response('Hello, world!')
+      }
+    `,
+      filename: 'pages/_middleware.js',
+    },
+    {
+      code: `import { NextFetchEvent, NextRequest } from "next/server"
+
+      export function middleware(req, ev) {
+        return new Response('Hello, world!')
+      }
+    `,
+      filename: `pages${path.sep}_middleware.js`,
+    },
+    {
+      code: `import NextDocument from "next/document"
+
+      export function middleware(req, ev) {
+        return new Response('Hello, world!')
+      }
+    `,
+      filename: `pages${path.posix.sep}_middleware.tsx`,
+    },
+    {
+      code: `import { NextFetchEvent, NextRequest } from "next/server"
+
+      export function middleware(req, ev) {
+        return new Response('Hello, world!')
+      }
+    `,
+      filename: 'pages/_middleware.page.tsx',
+    },
+    {
+      code: `import { NextFetchEvent, NextRequest } from "next/server"
+
+      export function middleware(req, ev) {
+        return new Response('Hello, world!')
+      }
+    `,
+      filename: 'pages/_middleware/index.js',
+    },
+    {
+      code: `import { NextFetchEvent, NextRequest } from "next/server"
+
+      export function middleware(req, ev) {
+        return new Response('Hello, world!')
+      }
+    `,
+      filename: 'pages/_middleware/index.tsx',
+    },
+    {
+      code: `import { NextFetchEvent, NextRequest } from "next/server"
+
+      export function middleware(req, ev) {
+        return new Response('Hello, world!')
+      }
+    `,
+      filename: 'pagesapp/src/pages/_middleware.js',
+    },
+  ],
+  invalid: [
+    {
+      code: `import { NextFetchEvent, NextRequest } from "next/server"
+
+      export const Test = () => <p>Test</p>
+      `,
+      filename: 'components/test.js',
+      errors: [
+        {
+          message:
+            'next/server should not be imported outside of pages/_middleware.js. See https://nextjs.org/docs/messages/no-server-import-in-page.',
+          type: 'ImportDeclaration',
+        },
+      ],
+    },
+    {
+      code: `import { NextFetchEvent, NextRequest } from "next/server"
+
+      export const Test = () => <p>Test</p>
+      `,
+      filename: 'pages/test.js',
+      errors: [
+        {
+          message:
+            'next/server should not be imported outside of pages/_middleware.js. See https://nextjs.org/docs/messages/no-server-import-in-page.',
+          type: 'ImportDeclaration',
+        },
+      ],
+    },
+    {
+      code: `import { NextFetchEvent, NextRequest } from "next/server"
+
+      export const Test = () => <p>Test</p>
+      `,
+      filename: `pages${path.sep}test.js`,
+      errors: [
+        {
+          message:
+            'next/server should not be imported outside of pages/_middleware.js. See https://nextjs.org/docs/messages/no-server-import-in-page.',
+          type: 'ImportDeclaration',
+        },
+      ],
+    },
+  ],
+})


### PR DESCRIPTION
Fixes https://github.com/vercel/next.js/issues/30921

Based on https://nextjs.org/docs/messages/no-document-import-in-page